### PR TITLE
Noise reduction and Node compatibility fixes

### DIFF
--- a/.changeset/selfish-llamas-change.md
+++ b/.changeset/selfish-llamas-change.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': minor
+---
+
+`keepFresh`: Reduce noise from unnecessary lock file-only dep updates

--- a/.changeset/strong-penguins-reflect.md
+++ b/.changeset/strong-penguins-reflect.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': minor
+---
+
+`restrictNode`: enable `constraintsFiltering` to prevent installing deps with incompatible `engines.node`

--- a/.changeset/tricky-fans-prove.md
+++ b/.changeset/tricky-fans-prove.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': patch
+---
+
+Restrict npm package-specific presets to only apply to npm deps

--- a/README.md
+++ b/README.md
@@ -102,14 +102,16 @@ In this section, ONLY edit between "extra content" marker comments!
 - [Compatibility presets](#compatibility-presets)
   - [disableEsmVersions](#disableesmversions)
   - [restrictNode](#restrictnodearg0)
+- [Freshness and noise reduction presets](#freshness-and-noise-reduction-presets)
+  - [keepFresh](#keepfresh)
+  - [minorDependencyUpdates](#minordependencyupdates)
+  - [scheduleNoisy](#schedulenoisy)
 - [Other presets](#other-presets)
   - [automergeDevLock](#automergedevlock)
   - [automergeTypes](#automergetypes)
   - [beachballPostUpgrade](#beachballpostupgrade)
   - [dependencyDashboardMajor](#dependencydashboardmajor)
-  - [keepFresh](#keepfresh)
   - [newConfigWarningIssue](#newconfigwarningissue)
-  - [scheduleNoisy](#schedulenoisy)
   <!-- end presets TOC -->
 
 <!-- start presets -->
@@ -604,6 +606,7 @@ Group minor and patch updates to `@types` `devDependencies`.
     {
       "groupName": "@types devDependencies",
       "schedule": ["before 5am on the 1st and 15th day of the month"],
+      "matchManagers": ["npm"],
       "matchPackagePrefixes": ["@types/"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -622,6 +625,7 @@ Group minor and patch updates to `@types` `devDependencies`.
     },
     {
       "groupName": "@types devDependencies",
+      "matchManagers": ["npm"],
       "matchPackagePrefixes": ["@types/"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch"],
@@ -726,7 +730,7 @@ While ES modules are the new standard, migrating immediately may not be practica
 
 #### `restrictNode(<arg0>)`
 
-Restrict Node version to the range `arg0`.
+Restrict Node version to the range `arg0` and ignore updates incompatible with your repo's `engines.node`.
 
 <details><summary><b>Show config JSON</b></summary>
 
@@ -736,6 +740,10 @@ Restrict Node version to the range `arg0`.
     {
       "matchPackageNames": ["@types/node", "node", "nodejs/node"],
       "allowedVersions": "{{arg0}}"
+    },
+    {
+      "matchManagers": ["npm"],
+      "constraintsFiltering": "strict"
     }
   ]
 }
@@ -751,6 +759,137 @@ It does NOT work for `actions/setup-node` (GitHub workflows) or `NodeTool` (Azur
 
 - Specify `engines.node` in `package.json` and specify `node-version-file: package.json` in the action, or
 - Create a `.nvmrc` file and specify `node-version-file: .nvmrc` in the action
+
+The preset also enables [`constraintsFiltering: "strict"`](https://docs.renovatebot.com/configuration-options/#constraintsfiltering) to prevent installing deps that are incompatible with your repo's `engines.node` setting.
+
+<!-- end extra content -->
+
+---
+
+### Freshness and noise reduction presets
+
+#### `keepFresh`
+
+Keep locally-used dependency versions updated and deduplicated.
+
+<details><summary><b>Show config JSON</b></summary>
+
+```json
+{
+  "extends": ["github>microsoft/m365-renovate-config:minorDependencyUpdates"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "rebaseWhen": "behind-base-branch",
+    "schedule": ["before 5am on the 1st and 15th day of the month"]
+  },
+  "postUpdateOptions": ["yarnDedupeFewer", "npmDedupe"],
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "replace"
+    }
+  ]
+}
+```
+
+</details>
+
+<!-- start extra content (EDITABLE between these comments) -->
+
+- [`lockFileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance): Completely re-create lock files twice a month. This will update direct and indirect dependency versions used _only within the repo_ to the latest versions that satisfy semver.
+  - [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen): If the lock file maintenance PR gets out of date, rebase it even if there aren't conflicts.
+- [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions):
+  - `yarnDedupeFewer`: If using yarn, run `yarn-deduplicate --strategy fewer` after updates.
+  - `npmDedupe`: If using npm, run `npm dedupe` after updates. WARNING: This may slow down Renovate runs significantly.
+- Extend [`<m365>:minorDependencyUpdates`](#minordependencyupdates) and set the [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy) for `npm` `devDependencies` to `replace` (see below for details).
+
+With `dependencies` and/or `devDependencies` specified as ranges (unpinned), by default Renovate will make individual lockfile-only update PRs for in-range updates. These PRs are redundant when `lockFileMaintenance` is also enabled, so the the `<m365>:minorDependencyUpdates` preset and the `packageRules` rule for `devDependencies` here help reduce unnecessary PRs.
+
+(To unpin your `devDependencies` that Renovate previously pinned, run `npx better-deps unpin-dev-deps`.)
+
+It's **highly recommended** to manually run the deduplication command (`npx yarn-deduplicate --strategy fewer` or `npm dedupe`) before enabling this preset. In a large repo that hasn't been regularly deduplicated or had its lock file refreshed, it's likely that initial deduplication will cause build breaks due to implicit reliance on subtle interactions between particular old versions.
+
+<!-- end extra content -->
+
+---
+
+#### `minorDependencyUpdates`
+
+For dependencies, explicitly pick up minor updates, and ignore patch updates if in-range.
+
+<details><summary><b>Show config JSON</b></summary>
+
+```json
+{
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchCurrentValue": "/^[~^][1-9]/",
+      "matchUpdateTypes": ["minor"],
+      "schedule": ["before 5am on Tuesday"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchCurrentVersion": "0.x",
+      "matchUpdateTypes": ["patch"],
+      "schedule": ["before 5am on Tuesday"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchCurrentValue": "/^[~^][1-9]/",
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    }
+  ]
+}
+```
+
+</details>
+
+<!-- start extra content (EDITABLE between these comments) -->
+
+This preset is mainly useful if `lockFileMaintenance` is enabled and some or all dependencies are specified as ranges. Note that it only applies to `npm` `dependencies`.
+
+- For all `npm` `dependencies`, set the [`rangeStrategy`](https://docs.renovatebot.com/configuration-options/#rangestrategy) to `bump`: bump the range even if the new version satisfies the existing range, e.g. `^1.0.0 -> ^1.1.0`.
+- For `^` or `~` `dependencies`:
+  - For versions > `0.x`, explicitly pick up minor updates once a week in case of API changes, and disable explicit patch updates.
+  - For `0.x` versions, explicitly pick up patch updates once a week in case of API changes.
+  <!-- end extra content -->
+
+---
+
+#### `scheduleNoisy`
+
+Update "noisy" (frequently-updating) packages once every other week.
+
+<details><summary><b>Show config JSON</b></summary>
+
+```json
+{
+  "packageRules": [
+    {
+      "matchPackagePrefixes": ["@microsoft/api-extractor"],
+      "schedule": ["before 5am on the 8th and 22nd day of the month"]
+    }
+  ]
+}
+```
+
+</details>
+
+<!-- start extra content (EDITABLE between these comments) -->
+
+Certain packages tend to publish updates multiple times per week, and getting a PR for every one of those updates can be annoying. This rule includes a list of packages known to update frequently and spreads them out throughout the week (to avoid attempting to create too many PRs at once and being rate limited).
+
 <!-- end extra content -->
 
 ---
@@ -806,6 +945,7 @@ Auto-merge minor and patch updates to `@types` `devDependencies` (if the build p
   "packageRules": [
     {
       "matchPackagePrefixes": ["@types/"],
+      "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackageNames": ["@types/react", "@types/react-dom"],
@@ -857,6 +997,7 @@ Run `beachball change` as a post-upgrade task.
   },
   "packageRules": [
     {
+      "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "postUpgradeTasks": {
         "commands": [
@@ -939,39 +1080,6 @@ Some alternative strategies which would need to be configured per repo (see [Ren
 
 ---
 
-#### `keepFresh`
-
-Keep locally-used dependency versions deduplicated and updated.
-
-<details><summary><b>Show config JSON</b></summary>
-
-```json
-{
-  "lockFileMaintenance": {
-    "enabled": true,
-    "rebaseWhen": "behind-base-branch",
-    "schedule": ["before 5am on the 1st and 15th day of the month"]
-  },
-  "postUpdateOptions": ["yarnDedupeFewer", "npmDedupe"]
-}
-```
-
-</details>
-
-<!-- start extra content (EDITABLE between these comments) -->
-
-- [`lockFileMaintenance`](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance): Completely re-create lock files twice a month. This will update direct and indirect dependency versions used _only within the repo_ to the latest versions that satisfy semver.
-  - [`rebaseWhen`](https://docs.renovatebot.com/configuration-options/#rebasewhen): If the lock file maintenance PR gets out of date, rebase it even if there aren't conflicts.
-- [`postUpdateOptions`](https://docs.renovatebot.com/configuration-options/#postupdateoptions):
-  - `yarnDedupeFewer`: If using yarn, run `yarn-deduplicate --strategy fewer` after updates.
-  - `npmDedupe`: If using npm, run `npm dedupe` after updates. WARNING: This may slow down Renovate runs significantly.
-
-It's **highly recommended** to manually run the deduplication command before enabling this preset. In a large repo that hasn't been regularly deduplicated (or had its lock file refreshed), it's likely that initial deduplication will cause build breaks due to implicit reliance on subtle interactions between particular old versions.
-
-<!-- end extra content -->
-
----
-
 #### `newConfigWarningIssue`
 
 Always create a new issue if there's a config problem (for visibility).
@@ -989,33 +1097,6 @@ Always create a new issue if there's a config problem (for visibility).
 <!-- start extra content (EDITABLE between these comments) -->
 
 Note that issue creation is not supported in Azure DevOps as of writing.
-
-<!-- end extra content -->
-
----
-
-#### `scheduleNoisy`
-
-Update "noisy" (frequently-updating) packages once every other week.
-
-<details><summary><b>Show config JSON</b></summary>
-
-```json
-{
-  "packageRules": [
-    {
-      "matchPackagePrefixes": ["@microsoft/api-extractor"],
-      "schedule": ["before 5am on the 8th and 22nd day of the month"]
-    }
-  ]
-}
-```
-
-</details>
-
-<!-- start extra content (EDITABLE between these comments) -->
-
-Certain packages tend to publish updates multiple times per week, and getting a PR for every one of those updates can be annoying. This rule includes a list of packages known to update frequently and spreads them out throughout the week (to avoid attempting to create too many PRs at once and being rate limited).
 
 <!-- end extra content -->
 

--- a/automergeTypes.json
+++ b/automergeTypes.json
@@ -6,6 +6,7 @@
   "packageRules": [
     {
       "matchPackagePrefixes": ["@types/"],
+      "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "excludePackageNames": ["@types/react", "@types/react-dom"],

--- a/beachballPostUpgrade.json
+++ b/beachballPostUpgrade.json
@@ -29,6 +29,7 @@
 
   "packageRules": [
     {
+      "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "postUpgradeTasks": {
         "commands": [

--- a/groupTypes.json
+++ b/groupTypes.json
@@ -7,6 +7,7 @@
     {
       "groupName": "@types devDependencies",
       "schedule": ["before 5am on the 1st and 15th day of the month"],
+      "matchManagers": ["npm"],
       "matchPackagePrefixes": ["@types/"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["minor", "patch"],
@@ -25,6 +26,7 @@
     },
     {
       "groupName": "@types devDependencies",
+      "matchManagers": ["npm"],
       "matchPackagePrefixes": ["@types/"],
       "matchDepTypes": ["devDependencies"],
       "matchUpdateTypes": ["patch"],

--- a/keepFresh.json
+++ b/keepFresh.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  "description": "Keep locally-used dependency versions deduplicated and updated.",
+  "description": "Keep locally-used dependency versions updated and deduplicated.",
+
+  "extends": ["github>microsoft/m365-renovate-config:minorDependencyUpdates"],
 
   "lockFileMaintenance": {
     "enabled": true,
@@ -9,5 +11,13 @@
     "schedule": ["before 5am on the 1st and 15th day of the month"]
   },
 
-  "postUpdateOptions": ["yarnDedupeFewer", "npmDedupe"]
+  "postUpdateOptions": ["yarnDedupeFewer", "npmDedupe"],
+
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "rangeStrategy": "replace"
+    }
+  ]
 }

--- a/minorDependencyUpdates.json
+++ b/minorDependencyUpdates.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "description": "For dependencies, explicitly pick up minor updates, and ignore patch updates if in-range.",
+
+  "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "rangeStrategy": "bump"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchCurrentValue": "/^[~^][1-9]/",
+      "matchUpdateTypes": ["minor"],
+      "schedule": ["before 5am on Tuesday"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchCurrentVersion": "0.x",
+      "matchUpdateTypes": ["patch"],
+      "schedule": ["before 5am on Tuesday"]
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchCurrentValue": "/^[~^][1-9]/",
+      "matchUpdateTypes": ["patch"],
+      "enabled": false
+    }
+  ]
+}

--- a/restrictNode.json
+++ b/restrictNode.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
 
-  "description": "Restrict Node version to the range `arg0`.",
+  "description": "Restrict Node version to the range `arg0` and ignore updates incompatible with your repo's `engines.node`.",
 
   "packageRules": [
     {
       "matchPackageNames": ["@types/node", "node", "nodejs/node"],
       "allowedVersions": "{{arg0}}"
+    },
+    {
+      "matchManagers": ["npm"],
+      "constraintsFiltering": "strict"
     }
   ]
 }

--- a/scripts/updateReadme.js
+++ b/scripts/updateReadme.js
@@ -49,6 +49,10 @@ const presetGroups = [
     presets: ['disableEsmVersions', 'restrictNode'],
   },
   {
+    name: 'Freshness and noise reduction presets',
+    presets: ['keepFresh', 'minorDependencyUpdates', 'scheduleNoisy'],
+  },
+  {
     // This group MUST be last!
     name: 'Other presets',
     presets: [],


### PR DESCRIPTION
- `keepFresh`: Reduce noise from unnecessary lock file-only dep updates
- `restrictNode`: enable `constraintsFiltering` to prevent installing deps with incompatible `engines.node`
- Restrict npm package-specific presets to only apply to npm deps