### PR TITLE
Pin actions to specific commits by default

### DIFF
--- a/.changeset/major-poems-feel.md
+++ b/.changeset/major-poems-feel.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': minor
+---
+
+Pin actions to specific commits by default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.ref }}-ci
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -1121,12 +1121,14 @@ Pin action versions.
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "pinDigest": true
+      "pinDigest": {
+        "enabled": true
+      }
     },
     {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["pinDigest"],
-      "pullRequestTitle": "Pin GitHub Actions versions"
+      "commitMessageTopic": "GitHub Actions versions"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ In this section, ONLY edit between "extra content" marker comments!
   - [beachballPostUpgrade](#beachballpostupgrade)
   - [dependencyDashboardMajor](#dependencydashboardmajor)
   - [newConfigWarningIssue](#newconfigwarningissue)
+  - [pinActions](#pinactions)
   <!-- end presets TOC -->
 
 <!-- start presets -->
@@ -128,9 +129,10 @@ Recommended config which is intended to be appropriate for most projects.
 {
   "extends": [
     "config:recommended",
+    "github>microsoft/m365-renovate-config:dependencyDashboardMajor",
     "github>microsoft/m365-renovate-config:groupReact",
     "github>microsoft/m365-renovate-config:newConfigWarningIssue",
-    "github>microsoft/m365-renovate-config:dependencyDashboardMajor"
+    "github>microsoft/m365-renovate-config:pinActions"
   ],
   "prConcurrentLimit": 10,
   "prHourlyLimit": 2,
@@ -1103,6 +1105,38 @@ Always create a new issue if there's a config problem (for visibility).
 <!-- start extra content (EDITABLE between these comments) -->
 
 Note that issue creation is not supported in Azure DevOps as of writing.
+
+<!-- end extra content -->
+
+---
+
+#### `pinActions`
+
+Pin action versions.
+
+<details><summary><b>Show config JSON</b></summary>
+
+```json
+{
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigest": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["pinDigest"],
+      "pullRequestTitle": "Pin GitHub Actions versions"
+    }
+  ]
+}
+```
+
+</details>
+
+<!-- start extra content (EDITABLE between these comments) -->
+
+Actions should be pinned to a specific immutable commit hash for security.
 
 <!-- end extra content -->
 

--- a/default.json
+++ b/default.json
@@ -5,9 +5,10 @@
 
   "extends": [
     "config:recommended",
+    "github>microsoft/m365-renovate-config:dependencyDashboardMajor",
     "github>microsoft/m365-renovate-config:groupReact",
     "github>microsoft/m365-renovate-config:newConfigWarningIssue",
-    "github>microsoft/m365-renovate-config:dependencyDashboardMajor"
+    "github>microsoft/m365-renovate-config:pinActions"
   ],
 
   "prConcurrentLimit": 10,

--- a/pinActions.json
+++ b/pinActions.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+
+  "description": "Pin action versions.",
+
+  "packageRules": [
+    {
+      "matchManagers": ["github-actions"],
+      "pinDigest": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["pinDigest"],
+      "pullRequestTitle": "Pin GitHub Actions versions"
+    }
+  ]
+}

--- a/pinActions.json
+++ b/pinActions.json
@@ -6,12 +6,14 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
-      "pinDigest": true
+      "pinDigest": {
+        "enabled": true
+      }
     },
     {
       "matchManagers": ["github-actions"],
       "matchUpdateTypes": ["pinDigest"],
-      "pullRequestTitle": "Pin GitHub Actions versions"
+      "commitMessageTopic": "GitHub Actions versions"
     }
   ]
 }

--- a/scripts/testPresetsFull.js
+++ b/scripts/testPresetsFull.js
@@ -1,3 +1,5 @@
+/** @import { RenovateLog } from './utils/types.js' */
+
 import fs from 'fs';
 import path from 'path';
 import { getExtendsForLocalPreset } from './utils/extends.js';
@@ -15,6 +17,9 @@ import { root } from './utils/paths.js';
 import { readPresets } from './utils/readPresets.js';
 import { logRenovateErrorDetails, readRenovateLogs } from './utils/renovateLogs.js';
 import { runBin } from './utils/runBin.js';
+
+/** @typedef {RenovateLog & { preset: string }} RenovatePresetDebugLog */
+/** */
 
 async function runTests() {
   const ref = getEnv('GITHUB_REF', isGithub);
@@ -100,10 +105,6 @@ async function runTests() {
 
 /** @param {string} logFile */
 function logRenovateError(logFile) {
-  /**
-   * @typedef {import('./utils/types.js').RenovateLog} RenovateLog
-   * @typedef {RenovateLog & { preset: string }} RenovatePresetDebugLog
-   */
   const logs = readRenovateLogs(logFile);
 
   const invalidPresetLog = logs.find((l) => !!l.err && l.msg === 'config-presets-invalid');

--- a/scripts/utils/renovateLogs.js
+++ b/scripts/utils/renovateLogs.js
@@ -1,10 +1,7 @@
+/** @import { RenovateLog, RenovateLogLevel } from './types.js' */
+
 import fs from 'fs';
 import { logEndGroup, logGroup } from './github.js';
-
-/**
- * @typedef {import('./types.js').RenovateLog} RenovateLog
- * @typedef {import('./types.js').RenovateLogLevel} RenovateLogLevel
- */
 
 /**
  * Renovate log level values

--- a/scripts/utils/types.d.ts
+++ b/scripts/utils/types.d.ts
@@ -32,7 +32,7 @@ export type RenovateLog = {
   [key: string]: any;
 };
 
-export type RenovatePreset = {
+type RenovatePreset = {
   extends?: string[];
   ignorePresets?: string[];
   // add more as needed


### PR DESCRIPTION
For security, it's best to pin actions to specific immutable commit hashes.