### PR TITLE
Fix beachball postupgrade for npm only

### DIFF
--- a/.changeset/few-crabs-appear.md
+++ b/.changeset/few-crabs-appear.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': patch
+---
+
+Fix method for only using beachball post-upgrade with npm

--- a/README.md
+++ b/README.md
@@ -983,27 +983,33 @@ Run `beachball change` as a post-upgrade task.
 ```json
 {
   "gitAuthor": "Renovate Bot <renovate@whitesourcesoftware.com>",
-  "postUpgradeTasks": {
-    "commands": [
-      "git add --all",
-      "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
-      "git reset"
-    ],
-    "fileFilters": ["**/package.json"],
-    "executionMode": "branch"
-  },
-  "lockFileMaintenance": {
-    "postUpgradeTasks": {
-      "commands": [
-        "git add --all",
-        "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-        "git reset"
-      ],
-      "fileFilters": ["**/package.json"],
-      "executionMode": "branch"
-    }
-  },
   "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["!lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": [
+          "git add --all",
+          "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
+          "git reset"
+        ],
+        "fileFilters": ["change/*"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": [
+          "git add --all",
+          "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
+          "git reset"
+        ],
+        "fileFilters": ["change/*"],
+        "executionMode": "branch"
+      }
+    },
     {
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
@@ -1013,7 +1019,7 @@ Run `beachball change` as a post-upgrade task.
           "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
           "git reset"
         ],
-        "fileFilters": ["**/package.json"],
+        "fileFilters": ["change/*"],
         "executionMode": "branch"
       }
     }

--- a/beachballLibraryVerbose.json
+++ b/beachballLibraryVerbose.json
@@ -5,30 +5,35 @@
 
   "extends": ["github>microsoft/m365-renovate-config:beachballLibraryRecommended"],
 
-  "postUpgradeTasks": {
-    "commands": [
-      "git add --all",
-      "npx --verbose beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
-      "git reset"
-    ],
-    "fileFilters": ["**/*"],
-    "executionMode": "branch"
-  },
-
-  "lockFileMaintenance": {
-    "postUpgradeTasks": {
-      "commands": [
-        "git add --all",
-        "npx --verbose beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-        "git reset"
-      ],
-      "fileFilters": ["**/*"],
-      "executionMode": "branch"
-    }
-  },
-
   "packageRules": [
     {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["!lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": [
+          "git add --all",
+          "npx --verbose beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
+          "git reset"
+        ],
+        "fileFilters": ["change/*"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": [
+          "git add --all",
+          "npx --verbose beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
+          "git reset"
+        ],
+        "fileFilters": ["change/*"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
       "postUpgradeTasks": {
         "commands": [
@@ -36,7 +41,7 @@
           "npx --verbose beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
           "git reset"
         ],
-        "fileFilters": ["**/*"],
+        "fileFilters": ["change/*"],
         "executionMode": "branch"
       }
     }

--- a/beachballPostUpgrade.json
+++ b/beachballPostUpgrade.json
@@ -5,29 +5,33 @@
 
   "gitAuthor": "Renovate Bot <renovate@whitesourcesoftware.com>",
 
-  "postUpgradeTasks": {
-    "commands": [
-      "git add --all",
-      "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
-      "git reset"
-    ],
-    "fileFilters": ["**/package.json"],
-    "executionMode": "branch"
-  },
-
-  "lockFileMaintenance": {
-    "postUpgradeTasks": {
-      "commands": [
-        "git add --all",
-        "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-        "git reset"
-      ],
-      "fileFilters": ["**/package.json"],
-      "executionMode": "branch"
-    }
-  },
-
   "packageRules": [
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["!lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": [
+          "git add --all",
+          "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
+          "git reset"
+        ],
+        "fileFilters": ["change/*"],
+        "executionMode": "branch"
+      }
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "postUpgradeTasks": {
+        "commands": [
+          "git add --all",
+          "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
+          "git reset"
+        ],
+        "fileFilters": ["change/*"],
+        "executionMode": "branch"
+      }
+    },
     {
       "matchManagers": ["npm"],
       "matchDepTypes": ["devDependencies"],
@@ -37,7 +41,7 @@
           "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
           "git reset"
         ],
-        "fileFilters": ["**/package.json"],
+        "fileFilters": ["change/*"],
         "executionMode": "branch"
       }
     }


### PR DESCRIPTION
`postUpgradeTasks.fileFilters` sets **which files are committed**, not which ones are considered for whether to run the task, so `fileFilters: ["**/package.json"]` doesn't work. Try moving everything to `packageRules` with `matchManagers: ["npm"]` instead.