### PR TITLE
Prevent accidental node updates lumped with github actions updates

### DIFF
--- a/.changeset/spotty-owls-sing.md
+++ b/.changeset/spotty-owls-sing.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': patch
+---
+
+Prevent accidental node updates lumped with github actions updates

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Group and auto-update official GitHub Actions.
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions (official)",
       "matchPackageNames": ["actions/*", "github/*"],
+      "matchDepTypes": ["action"],
       "dependencyDashboardApproval": false
     }
   ]
@@ -273,6 +274,8 @@ Group and auto-update official GitHub Actions.
 </details>
 
 <!-- start extra content (EDITABLE between these comments) -->
+
+This is set to only `matchDepTypes: ["action"]` because of [newer "actions" dependency types](https://docs.renovatebot.com/modules/manager/github-actions/#dependency-types) which should be updated separately.
 
 <!-- end extra content -->
 
@@ -778,7 +781,7 @@ Restrict Node version to the range `arg0` and ignore updates incompatible with y
 {
   "packageRules": [
     {
-      "matchPackageNames": ["@types/node", "node", "nodejs/node"],
+      "matchPackageNames": ["@types/node", "node", "nodejs/node", "node-version"],
       "allowedVersions": "{{arg0}}"
     },
     {

--- a/groupActions.json
+++ b/groupActions.json
@@ -8,6 +8,7 @@
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions (official)",
       "matchPackageNames": ["actions/*", "github/*"],
+      "matchDepTypes": ["action"],
       "dependencyDashboardApproval": false
     }
   ]

--- a/restrictNode.json
+++ b/restrictNode.json
@@ -5,7 +5,7 @@
 
   "packageRules": [
     {
-      "matchPackageNames": ["@types/node", "node", "nodejs/node"],
+      "matchPackageNames": ["@types/node", "node", "nodejs/node", "node-version"],
       "allowedVersions": "{{arg0}}"
     },
     {


### PR DESCRIPTION
`groupActions` recently started generating automatic hidden node updates like this even with `restrictNode`...
<img width="501" height="119" alt="image" src="https://github.com/user-attachments/assets/a4b0efc3-c7f2-455e-b4d1-02eadbf703ba" />

Pretty sure this [`uses-with` dep type](https://docs.renovatebot.com/modules/manager/github-actions/#dependency-types) inside the `actions` manager is new? And/or possibly a bad interaction of ordering between `restrictNode` and `groupActions`?