### PR TITLE
Update minimum release age

### DIFF
--- a/.changeset/violet-rats-battle.md
+++ b/.changeset/violet-rats-battle.md
@@ -1,0 +1,5 @@
+---
+'@microsoft/m365-renovate-config': patch
+---
+
+Update default minimumReleaseAge to 7d for npm, 3d for others

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,8 @@
 
   "lockFileMaintenance": {
     "automerge": true,
-    "platformAutomerge": true
+    "platformAutomerge": true,
+    "schedule": ["before 5am on the 1st day of the month"]
   },
 
   "semanticCommits": "disabled",
@@ -27,11 +28,11 @@
       "matchPackageNames": ["*"],
       "matchUpdateTypes": ["minor", "patch"],
       "matchDepNames": ["!renovate"],
-      "schedule": ["before 5am on the 5th and 20th day of the month"]
+      "schedule": ["before 5am on the 1st day of the month"]
     },
     {
       "matchPackageNames": ["renovate"],
-      "schedule": ["before 5am on the 10th and 25th day of the month"]
+      "schedule": ["before 5am on the 1st day of the month"]
     }
   ]
 }

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,6 +3,6 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 3d
+npmMinimalAgeGate: 7d
 
 yarnPath: .yarn/releases/yarn-4.14.1.cjs

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ Recommended config which is intended to be appropriate for most projects.
     {
       "matchDepTypes": ["devDependencies"],
       "commitMessageTopic": "devDependency {{{depName}}}"
+    },
+    {
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }
@@ -174,7 +178,7 @@ Extended presets from this repo:
 Other settings:
 
 - PR limits (`prHourlyLimit` and `prConcurrentLimit`): Prevent Renovate from creating an overwhelming number of PRs all at once. It's _highly encouraged_ to adjust these in your repo to fit your team's needs!
-- `minimumReleaseAge`: Wait 3 days to auto-create PRs for new releases (they'll be shown on the dependency dashboard earlier), mainly in case of security issues. Though note that this doesn't mitigate the more likely issue of bad packages pulled in by lock file updates.
+- `minimumReleaseAge`: Wait 3 or 7 days to auto-create PRs for new releases (they'll be shown on the dependency dashboard earlier), mainly in case of security issues. You should also apply a similar package manager setting to restrict lock file updates from pulling in new versions.
 - `printConfig`: Log the final resolved config to make debugging easier
 - `timezone`: Run schedules relative to Pacific time, since many M365 repos are based in that time zone. See the [time zone list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) for other options.
 - `vulnerabilityAlerts`: Enable PRs to address security vulnerabilities. Note that this **only** works for GitHub and currently is **only** able to update direct dependencies (except in repos using `npm` 6 or older).

--- a/default.json
+++ b/default.json
@@ -28,6 +28,10 @@
     {
       "matchDepTypes": ["devDependencies"],
       "commitMessageTopic": "devDependency {{{depName}}}"
+    },
+    {
+      "matchManagers": ["npm"],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }

--- a/scripts/checkToken.ts
+++ b/scripts/checkToken.ts
@@ -1,5 +1,4 @@
 import fetch, { type Response } from 'node-fetch';
-import { pathToFileURL } from 'url';
 import { getEnv } from './utils/getEnv.ts';
 import { logError } from './utils/github.ts';
 
@@ -38,13 +37,10 @@ export async function checkToken(token: string | undefined = getToken()) {
   }
 }
 
-// ESM version of `if (require.main === module)`
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
-  (async () => {
-    await checkToken(process.argv[2]);
-    console.log('Token is valid');
-  })().catch((err) => {
+if (import.meta.main) {
+  await checkToken(process.argv[2]).catch((err) => {
     logError(err);
     process.exit(1);
   });
+  console.log('Token is valid');
 }


### PR DESCRIPTION
7d for npm, keep 3d for others. Also set corresponding yarn config, and slow down the PR cadence in this repo.